### PR TITLE
chore(release): fix semantic-release config for ESM

### DIFF
--- a/release.config.cjs
+++ b/release.config.cjs
@@ -1,5 +1,5 @@
 module.exports = {
-  branches: ['main', 'master', { name: 'next', prerelease: true }],
+  branches: ['main', { name: 'next', prerelease: true }],
   plugins: [
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
@@ -19,3 +19,5 @@ module.exports = {
     '@semantic-release/github'
   ]
 };
+
+


### PR DESCRIPTION
Rename release.config.js to release.config.cjs so semantic-release loads under type=module; remove master branch references remain.